### PR TITLE
Improved AppleSkin compat

### DIFF
--- a/src/main/java/com/minecraftabnormals/mindful_eating/client/HungerOverlay.java
+++ b/src/main/java/com/minecraftabnormals/mindful_eating/client/HungerOverlay.java
@@ -80,11 +80,14 @@ public class HungerOverlay {
         int level = stats.getFoodLevel();
         int ticks = minecraft.gui.getGuiTicks();
         float modifiedSaturation = Math.min(stats.getSaturationLevel(), 20);
+        float previewSaturation;
         AppleskinPreview preview;
         if (AppleskinCompat.INSTANCE != null) {
             preview = AppleskinCompat.INSTANCE.getCurrentPreview();
+            previewSaturation = Math.min(preview.saturationLevel, 20);
         } else {
             preview = new AppleskinPreview();
+            previewSaturation = modifiedSaturation;
         }
 
         int yOffset = player.tickCount % Mth.ceil(10 + 5.0F);
@@ -144,7 +147,7 @@ public class HungerOverlay {
                 guiGraphics.blit(texture, x, y, icon + 45, group, 9, 9, 126, 45);
             }
 
-            if (preview.isActive && idx >= level && idx <= preview.hungerLevel) {
+            if (preview.isActive && idx >= level && idx <= preview.hungerLevel && preview.alpha > 0.0F) {
                 int preview_level = preview.hungerLevel;
 
                 // very faint background
@@ -161,7 +164,7 @@ public class HungerOverlay {
 
             if (FabricLoader.getInstance().isModLoaded("appleskin")) {
                 if (!ModConfig.INSTANCE.showSaturationHudOverlay)
-                    return;
+                    continue;
                 float effectiveSaturationOfBar = (modifiedSaturation / 2.0F) - i;
 
                 int u;
@@ -178,6 +181,27 @@ public class HungerOverlay {
                     u = 0;
 
                 guiGraphics.blit(GUI_SATURATION_ICONS_LOCATION, x, y, u, group, 9, 9, 126, 45);
+
+                if (preview.isActive && previewSaturation > modifiedSaturation && previewSaturation / 2.0F > i && modifiedSaturation / 2.0F < i + 1 && preview.alpha > 0.0F) {
+                    float effectiveSaturationOfPreviewBar = (previewSaturation / 2.0F) - i;
+
+                    int u2;
+
+                    if (effectiveSaturationOfPreviewBar >= 1)
+                        u2 = 4 * 9;
+                    else if (effectiveSaturationOfPreviewBar > .75)
+                        u2 = 3 * 9;
+                    else if (effectiveSaturationOfPreviewBar > .5)
+                        u2 = 2 * 9;
+                    else if (effectiveSaturationOfPreviewBar > .25)
+                        u2 = 9;
+                    else
+                        u2 = 0;
+
+                    RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, preview.alpha);
+                    guiGraphics.blit(GUI_SATURATION_ICONS_LOCATION, x, y, u2, group, 9, 9, 126, 45);
+                    RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
+                }
             }
         }
         if (preview.isActive) disableAlpha();

--- a/src/main/java/com/minecraftabnormals/mindful_eating/compat/AppleskinCompat.java
+++ b/src/main/java/com/minecraftabnormals/mindful_eating/compat/AppleskinCompat.java
@@ -1,7 +1,7 @@
 package com.minecraftabnormals.mindful_eating.compat;
 
 import net.minecraft.client.Minecraft;
-import squeek.appleskin.api.event.HUDOverlayEvent;
+import net.minecraft.world.item.ItemStack;
 
 public class AppleskinCompat {
     public static AppleskinCompat INSTANCE;
@@ -26,11 +26,12 @@ public class AppleskinCompat {
         currentPreview = new AppleskinPreview();
     }
 
-    public void updateHungerPreview(int hungerRestored, int foodLevel, Minecraft mc, int right, int top, float alpha, boolean useRotten) {
+    public void updateHungerPreview(int hungerRestored, int foodLevel, Minecraft mc, int right, int top, float alpha, boolean useRotten, ItemStack heldItem) {
         currentPreview.isActive = true;
         currentPreview.alpha = alpha;
         currentPreview.hungerLevel = Math.max(0, Math.min(20, foodLevel + hungerRestored));
         currentPreview.useRotten = useRotten;
+        currentPreview.heldItem = heldItem;
     }
 
     public void updateSaturationPreview(float saturationRestored, float saturationLevel, Minecraft mc, int right, int top, float alpha) {

--- a/src/main/java/com/minecraftabnormals/mindful_eating/compat/AppleskinCompat.java
+++ b/src/main/java/com/minecraftabnormals/mindful_eating/compat/AppleskinCompat.java
@@ -1,17 +1,38 @@
 package com.minecraftabnormals.mindful_eating.compat;
 
-import net.minecraft.client.gui.GuiGraphics;
-import net.minecraft.resources.ResourceLocation;
+import net.minecraft.client.Minecraft;
 import squeek.appleskin.api.event.HUDOverlayEvent;
 
 public class AppleskinCompat {
-    public static void init() {
-        // HUDOverlayEvent.Saturation.EVENT.register(saturation ->
-        //         saturation.isCanceled = true
-        // );
+    public static AppleskinCompat INSTANCE;
 
-        // HUDOverlayEvent.HungerRestored.EVENT.register(hungerRestored ->
-        //         hungerRestored.isCanceled = true
-        // );
+    private AppleskinPreview currentPreview;
+
+    AppleskinCompat() {
+        this.currentPreview = new AppleskinPreview();
+    }
+
+    public static void init() {
+        if (INSTANCE == null) {
+            INSTANCE = new AppleskinCompat();
+        }
+        HUDOverlayEvent.Saturation.EVENT.register(saturation ->
+                saturation.isCanceled = true
+        );
+    }
+
+    public AppleskinPreview getCurrentPreview() {
+        return new AppleskinPreview(currentPreview);
+    }
+
+    public void resetPreview() {
+        currentPreview = new AppleskinPreview();
+    }
+
+    public void updateHungerPreview(int hungerRestored, int foodLevel, Minecraft mc, int right, int top, float alpha, boolean useRotten) {
+        currentPreview.isActive = true;
+        currentPreview.alpha = alpha;
+        currentPreview.hungerLevel = Math.max(0, Math.min(20, foodLevel + hungerRestored));
+        currentPreview.useRotten = useRotten;
     }
 }

--- a/src/main/java/com/minecraftabnormals/mindful_eating/compat/AppleskinCompat.java
+++ b/src/main/java/com/minecraftabnormals/mindful_eating/compat/AppleskinCompat.java
@@ -1,15 +1,17 @@
 package com.minecraftabnormals.mindful_eating.compat;
 
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.resources.ResourceLocation;
 import squeek.appleskin.api.event.HUDOverlayEvent;
 
 public class AppleskinCompat {
     public static void init() {
-        HUDOverlayEvent.Saturation.EVENT.register(saturation ->
-                saturation.isCanceled = true
-        );
+        // HUDOverlayEvent.Saturation.EVENT.register(saturation ->
+        //         saturation.isCanceled = true
+        // );
 
-        HUDOverlayEvent.HungerRestored.EVENT.register(hungerRestored ->
-                hungerRestored.isCanceled = true
-        );
+        // HUDOverlayEvent.HungerRestored.EVENT.register(hungerRestored ->
+        //         hungerRestored.isCanceled = true
+        // );
     }
 }

--- a/src/main/java/com/minecraftabnormals/mindful_eating/compat/AppleskinCompat.java
+++ b/src/main/java/com/minecraftabnormals/mindful_eating/compat/AppleskinCompat.java
@@ -16,9 +16,6 @@ public class AppleskinCompat {
         if (INSTANCE == null) {
             INSTANCE = new AppleskinCompat();
         }
-        HUDOverlayEvent.Saturation.EVENT.register(saturation ->
-                saturation.isCanceled = true
-        );
     }
 
     public AppleskinPreview getCurrentPreview() {
@@ -34,5 +31,11 @@ public class AppleskinCompat {
         currentPreview.alpha = alpha;
         currentPreview.hungerLevel = Math.max(0, Math.min(20, foodLevel + hungerRestored));
         currentPreview.useRotten = useRotten;
+    }
+
+    public void updateSaturationPreview(float saturationRestored, float saturationLevel, Minecraft mc, int right, int top, float alpha) {
+        currentPreview.isActive = true;
+        currentPreview.alpha = alpha;
+        currentPreview.saturationLevel = Math.min(20.0F, saturationLevel + saturationRestored);
     }
 }

--- a/src/main/java/com/minecraftabnormals/mindful_eating/compat/AppleskinPreview.java
+++ b/src/main/java/com/minecraftabnormals/mindful_eating/compat/AppleskinPreview.java
@@ -1,11 +1,14 @@
 package com.minecraftabnormals.mindful_eating.compat;
 
+import net.minecraft.world.item.ItemStack;
+
 public class AppleskinPreview {
     public boolean isActive;
     public boolean useRotten;
     public int hungerLevel;
     public float saturationLevel;
     public float alpha;
+    public ItemStack heldItem;
 
     public AppleskinPreview() {
         this.isActive = false;
@@ -13,14 +16,16 @@ public class AppleskinPreview {
         this.hungerLevel = 0;
         this.saturationLevel = 0.0F;
         this.alpha = 0.0F;
+        this.heldItem = null;
     }
 
-    public AppleskinPreview(boolean isActive, boolean useRotten, int hungerLevel, float saturationLevel, float alpha) {
+    public AppleskinPreview(boolean isActive, boolean useRotten, int hungerLevel, float saturationLevel, float alpha, ItemStack heldItem) {
         this.isActive = isActive;
         this.useRotten = useRotten;
         this.hungerLevel = hungerLevel;
         this.saturationLevel = saturationLevel;
         this.alpha = alpha;
+        this.heldItem = heldItem;
     }
 
     public AppleskinPreview(AppleskinPreview other) {
@@ -29,5 +34,6 @@ public class AppleskinPreview {
         this.hungerLevel = other.hungerLevel;
         this.saturationLevel = other.saturationLevel;
         this.alpha = other.alpha;
+        this.heldItem = other.heldItem;
     }
  }

--- a/src/main/java/com/minecraftabnormals/mindful_eating/compat/AppleskinPreview.java
+++ b/src/main/java/com/minecraftabnormals/mindful_eating/compat/AppleskinPreview.java
@@ -4,19 +4,22 @@ public class AppleskinPreview {
     public boolean isActive;
     public boolean useRotten;
     public int hungerLevel;
+    public float saturationLevel;
     public float alpha;
 
     public AppleskinPreview() {
         this.isActive = false;
         this.useRotten = false;
         this.hungerLevel = 0;
+        this.saturationLevel = 0.0F;
         this.alpha = 0.0F;
     }
 
-    public AppleskinPreview(boolean isActive, boolean useRotten, int hungerLevel, float alpha) {
+    public AppleskinPreview(boolean isActive, boolean useRotten, int hungerLevel, float saturationLevel, float alpha) {
         this.isActive = isActive;
         this.useRotten = useRotten;
         this.hungerLevel = hungerLevel;
+        this.saturationLevel = saturationLevel;
         this.alpha = alpha;
     }
 
@@ -24,6 +27,7 @@ public class AppleskinPreview {
         this.isActive = other.isActive;
         this.useRotten = other.useRotten;
         this.hungerLevel = other.hungerLevel;
+        this.saturationLevel = other.saturationLevel;
         this.alpha = other.alpha;
     }
  }

--- a/src/main/java/com/minecraftabnormals/mindful_eating/compat/AppleskinPreview.java
+++ b/src/main/java/com/minecraftabnormals/mindful_eating/compat/AppleskinPreview.java
@@ -1,0 +1,29 @@
+package com.minecraftabnormals.mindful_eating.compat;
+
+public class AppleskinPreview {
+    public boolean isActive;
+    public boolean useRotten;
+    public int hungerLevel;
+    public float alpha;
+
+    public AppleskinPreview() {
+        this.isActive = false;
+        this.useRotten = false;
+        this.hungerLevel = 0;
+        this.alpha = 0.0F;
+    }
+
+    public AppleskinPreview(boolean isActive, boolean useRotten, int hungerLevel, float alpha) {
+        this.isActive = isActive;
+        this.useRotten = useRotten;
+        this.hungerLevel = hungerLevel;
+        this.alpha = alpha;
+    }
+
+    public AppleskinPreview(AppleskinPreview other) {
+        this.isActive = other.isActive;
+        this.useRotten = other.useRotten;
+        this.hungerLevel = other.hungerLevel;
+        this.alpha = other.alpha;
+    }
+ }

--- a/src/main/java/com/minecraftabnormals/mindful_eating/compat/AppleskinTooltipRenderer.java
+++ b/src/main/java/com/minecraftabnormals/mindful_eating/compat/AppleskinTooltipRenderer.java
@@ -1,0 +1,8 @@
+package com.minecraftabnormals.mindful_eating.compat;
+
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.resources.ResourceLocation;
+
+public interface AppleskinTooltipRenderer {
+    void renderHungerTooltip(GuiGraphics context, ResourceLocation texture, int x, int y, int z, float u, float v, int width, int height, int textureWidth, int textureHeight, int i);
+}

--- a/src/main/java/com/minecraftabnormals/mindful_eating/core/mixin/appleskin/FoodOverlayMixin.java
+++ b/src/main/java/com/minecraftabnormals/mindful_eating/core/mixin/appleskin/FoodOverlayMixin.java
@@ -1,0 +1,52 @@
+package com.minecraftabnormals.mindful_eating.core.mixin.appleskin;
+
+import com.illusivesoulworks.diet.api.type.IDietGroup;
+import com.minecraftabnormals.mindful_eating.client.FoodGroups;
+import com.minecraftabnormals.mindful_eating.compat.AppleskinTooltipRenderer;
+import com.minecraftabnormals.mindful_eating.core.MindfulEatingFabric;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import squeek.appleskin.api.food.FoodValues;
+
+import java.util.Set;
+
+
+
+@Pseudo
+@Mixin(squeek.appleskin.client.TooltipOverlayHandler.FoodOverlay.class)
+public class FoodOverlayMixin implements AppleskinTooltipRenderer {
+    private static final ResourceLocation GUI_HUNGER_ICONS_LOCATION = new ResourceLocation(MindfulEatingFabric.MOD_ID, "textures/gui/hunger_icons.png");
+    private static final ResourceLocation GUI_NOURISHMENT_ICONS_LOCATION = new ResourceLocation(MindfulEatingFabric.MOD_ID, "textures/gui/nourished_icons.png");
+    private static final ResourceLocation GUI_SATURATION_ICONS_LOCATION = new ResourceLocation(MindfulEatingFabric.MOD_ID, "textures/gui/saturation_icons.png");
+
+    private IDietGroup[] groups;
+
+    @Inject(
+            method = "<init>(Lnet/minecraft/world/item/ItemStack;Lsqueek/appleskin/api/food/FoodValues;Lsqueek/appleskin/api/food/FoodValues;Lnet/minecraft/world/entity/player/Player;)V",
+            at = @At(value = "TAIL")
+    )
+    private void getDietGroups(ItemStack itemStack, FoodValues defaultFood, FoodValues modifiedFood, Player player, CallbackInfo info) {
+        if (player != null && itemStack != null) {
+            Set<IDietGroup> group_set = MindfulEatingFabric.DIET_API.getGroups(player, itemStack);
+            this.groups = group_set.toArray(new IDietGroup[0]);
+        }
+    }
+
+    public void renderHungerTooltip(GuiGraphics context, ResourceLocation texture, int x, int y, int z, float u, float v, int width, int height, int textureWidth, int textureHeight, int i) {
+        FoodGroups foodGroup;
+        if (groups == null || groups.length == 0) {
+            foodGroup = FoodGroups.PROTEINS;
+        } else {
+            foodGroup = FoodGroups.byDietGroup(groups[i % groups.length]);
+        }
+        int group = foodGroup != null ? foodGroup.getTextureOffset() : 0;
+        context.blit(GUI_HUNGER_ICONS_LOCATION, x, y, z, u - 16.0F, (float) group, width, height, 126, 45);
+    }
+}

--- a/src/main/java/com/minecraftabnormals/mindful_eating/core/mixin/appleskin/HUDOverlayHandlerMixin.java
+++ b/src/main/java/com/minecraftabnormals/mindful_eating/core/mixin/appleskin/HUDOverlayHandlerMixin.java
@@ -1,8 +1,10 @@
 package com.minecraftabnormals.mindful_eating.core.mixin.appleskin;
 
+import com.llamalad7.mixinextras.sugar.Local;
 import com.minecraftabnormals.mindful_eating.compat.AppleskinCompat;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.world.item.ItemStack;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Pseudo;
 import org.spongepowered.asm.mixin.injection.At;
@@ -29,9 +31,9 @@ public class HUDOverlayHandlerMixin {
             method = "onRender(Lnet/minecraft/client/gui/GuiGraphics;)V",
             at = @At(value = "INVOKE", target = "Lsqueek/appleskin/client/HUDOverlayHandler;drawHungerOverlay(Lsqueek/appleskin/api/event/HUDOverlayEvent$HungerRestored;Lnet/minecraft/client/Minecraft;IFZ)V", ordinal = 0)
     )
-    private static void drawHungerOverlay(HUDOverlayHandler handler, HUDOverlayEvent.HungerRestored event, Minecraft mc, int hunger, float alpha, boolean useRottenTextures) {
+    private static void drawHungerOverlay(HUDOverlayHandler handler, HUDOverlayEvent.HungerRestored event, Minecraft mc, int hunger, float alpha, boolean useRottenTextures, @Local(name = "heldItem") ItemStack heldItem) {
         if (AppleskinCompat.INSTANCE != null) {
-            AppleskinCompat.INSTANCE.updateHungerPreview(hunger, event.currentFoodLevel, mc, event.x, event.y, alpha, useRottenTextures);
+            AppleskinCompat.INSTANCE.updateHungerPreview(hunger, event.currentFoodLevel, mc, event.x, event.y, alpha, useRottenTextures, heldItem);
         }
     }
 

--- a/src/main/java/com/minecraftabnormals/mindful_eating/core/mixin/appleskin/HUDOverlayHandlerMixin.java
+++ b/src/main/java/com/minecraftabnormals/mindful_eating/core/mixin/appleskin/HUDOverlayHandlerMixin.java
@@ -1,0 +1,37 @@
+package com.minecraftabnormals.mindful_eating.core.mixin.appleskin;
+
+import com.minecraftabnormals.mindful_eating.compat.AppleskinCompat;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiGraphics;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import squeek.appleskin.api.event.HUDOverlayEvent;
+import squeek.appleskin.client.HUDOverlayHandler;
+
+@Pseudo
+@Mixin(squeek.appleskin.client.HUDOverlayHandler.class)
+public class HUDOverlayHandlerMixin {
+    @Inject(
+            method = "onRender(Lnet/minecraft/client/gui/GuiGraphics;)V",
+            at = @At(value = "HEAD")
+    )
+    private void getDietGroups(GuiGraphics context, CallbackInfo info) {
+        if (AppleskinCompat.INSTANCE != null) {
+            AppleskinCompat.INSTANCE.resetPreview();
+        }
+    }
+
+    @Redirect(
+            method = "onRender(Lnet/minecraft/client/gui/GuiGraphics;)V",
+            at = @At(value = "INVOKE", target = "Lsqueek/appleskin/client/HUDOverlayHandler;drawHungerOverlay(Lsqueek/appleskin/api/event/HUDOverlayEvent$HungerRestored;Lnet/minecraft/client/Minecraft;IFZ)V", ordinal = 0)
+    )
+    private static void drawHungerOverlay(HUDOverlayHandler handler, HUDOverlayEvent.HungerRestored event, Minecraft mc, int hunger, float alpha, boolean useRottenTextures) {
+        if (AppleskinCompat.INSTANCE != null) {
+            AppleskinCompat.INSTANCE.updateHungerPreview(hunger, event.currentFoodLevel, mc, event.x, event.y, alpha, useRottenTextures);
+        }
+    }
+}

--- a/src/main/java/com/minecraftabnormals/mindful_eating/core/mixin/appleskin/HUDOverlayHandlerMixin.java
+++ b/src/main/java/com/minecraftabnormals/mindful_eating/core/mixin/appleskin/HUDOverlayHandlerMixin.java
@@ -34,4 +34,20 @@ public class HUDOverlayHandlerMixin {
             AppleskinCompat.INSTANCE.updateHungerPreview(hunger, event.currentFoodLevel, mc, event.x, event.y, alpha, useRottenTextures);
         }
     }
+
+    @Redirect(
+            method = "onRender(Lnet/minecraft/client/gui/GuiGraphics;)V",
+            at = @At(value = "INVOKE", target = "Lsqueek/appleskin/client/HUDOverlayHandler;drawSaturationOverlay(Lsqueek/appleskin/api/event/HUDOverlayEvent$Saturation;Lnet/minecraft/client/Minecraft;FF)V", ordinal = 0)
+    )
+    private static void drawSaturationOverlay0(HUDOverlayHandler handler, HUDOverlayEvent.Saturation event, Minecraft mc, float saturationGained, float alpha) {}
+
+    @Redirect(
+            method = "onRender(Lnet/minecraft/client/gui/GuiGraphics;)V",
+            at = @At(value = "INVOKE", target = "Lsqueek/appleskin/client/HUDOverlayHandler;drawSaturationOverlay(Lsqueek/appleskin/api/event/HUDOverlayEvent$Saturation;Lnet/minecraft/client/Minecraft;FF)V", ordinal = 1)
+    )
+    private static void drawSaturationOverlay1(HUDOverlayHandler handler, HUDOverlayEvent.Saturation event, Minecraft mc, float saturationGained, float alpha) {
+        if (AppleskinCompat.INSTANCE != null) {
+            AppleskinCompat.INSTANCE.updateSaturationPreview(saturationGained, event.saturationLevel, mc, event.x, event.y, alpha);
+        }
+    }
 }

--- a/src/main/java/com/minecraftabnormals/mindful_eating/core/mixin/appleskin/TooltipOverlayHandlerMixin.java
+++ b/src/main/java/com/minecraftabnormals/mindful_eating/core/mixin/appleskin/TooltipOverlayHandlerMixin.java
@@ -1,0 +1,71 @@
+package com.minecraftabnormals.mindful_eating.core.mixin.appleskin;
+
+import com.llamalad7.mixinextras.sugar.Local;
+import com.minecraftabnormals.mindful_eating.compat.AppleskinTooltipRenderer;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.resources.ResourceLocation;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import squeek.appleskin.client.TooltipOverlayHandler;
+
+@Pseudo
+@Mixin(squeek.appleskin.client.TooltipOverlayHandler.class)
+public class TooltipOverlayHandlerMixin {
+    @Redirect(
+            method = "onRenderTooltip(Lnet/minecraft/client/gui/GuiGraphics;Lsqueek/appleskin/client/TooltipOverlayHandler$FoodOverlay;IIILnet/minecraft/client/gui/Font;)V",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/GuiGraphics;blit(Lnet/minecraft/resources/ResourceLocation;IIIFFIIII)V", ordinal = 0)
+    )
+    private void drawHungerTexture0(GuiGraphics context, ResourceLocation texture, int x, int y, int z, float u, float v, int width, int height, int textureWidth, int textureHeight, @Local(name = "i") int i, @Local(argsOnly = true) TooltipOverlayHandler.FoodOverlay foodOverlay) {
+        ((AppleskinTooltipRenderer) foodOverlay).renderHungerTooltip(context, texture, x, y, z, u, v, width, height, textureWidth, textureHeight, i);
+    }
+
+    @Redirect(
+            method = "onRenderTooltip(Lnet/minecraft/client/gui/GuiGraphics;Lsqueek/appleskin/client/TooltipOverlayHandler$FoodOverlay;IIILnet/minecraft/client/gui/Font;)V",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/GuiGraphics;blit(Lnet/minecraft/resources/ResourceLocation;IIIFFIIII)V", ordinal = 1)
+    )
+    private void drawHungerTexture1(GuiGraphics context, ResourceLocation texture, int x, int y, int z, float u, float v, int width, int height, int textureWidth, int textureHeight, @Local(name = "i") int i, @Local(argsOnly = true) TooltipOverlayHandler.FoodOverlay foodOverlay) {
+        ((AppleskinTooltipRenderer) foodOverlay).renderHungerTooltip(context, texture, x, y, z, u, v, width, height, textureWidth, textureHeight, i);
+    }
+
+    @Redirect(
+            method = "onRenderTooltip(Lnet/minecraft/client/gui/GuiGraphics;Lsqueek/appleskin/client/TooltipOverlayHandler$FoodOverlay;IIILnet/minecraft/client/gui/Font;)V",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/GuiGraphics;blit(Lnet/minecraft/resources/ResourceLocation;IIIFFIIII)V", ordinal = 2)
+    )
+    private void drawHungerTexture2(GuiGraphics context, ResourceLocation texture, int x, int y, int z, float u, float v, int width, int height, int textureWidth, int textureHeight, @Local(name = "i") int i, @Local(argsOnly = true) TooltipOverlayHandler.FoodOverlay foodOverlay) {
+        ((AppleskinTooltipRenderer) foodOverlay).renderHungerTooltip(context, texture, x, y, z, u, v, width, height, textureWidth, textureHeight, i);
+    }
+
+    @Redirect(
+            method = "onRenderTooltip(Lnet/minecraft/client/gui/GuiGraphics;Lsqueek/appleskin/client/TooltipOverlayHandler$FoodOverlay;IIILnet/minecraft/client/gui/Font;)V",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/GuiGraphics;blit(Lnet/minecraft/resources/ResourceLocation;IIIFFIIII)V", ordinal = 3)
+    )
+    private void drawHungerTexture3(GuiGraphics context, ResourceLocation texture, int x, int y, int z, float u, float v, int width, int height, int textureWidth, int textureHeight, @Local(name = "i") int i, @Local(argsOnly = true) TooltipOverlayHandler.FoodOverlay foodOverlay) {
+        ((AppleskinTooltipRenderer) foodOverlay).renderHungerTooltip(context, texture, x, y, z, u, v, width, height, textureWidth, textureHeight, i);
+    }
+
+    @Redirect(
+            method = "onRenderTooltip(Lnet/minecraft/client/gui/GuiGraphics;Lsqueek/appleskin/client/TooltipOverlayHandler$FoodOverlay;IIILnet/minecraft/client/gui/Font;)V",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/GuiGraphics;blit(Lnet/minecraft/resources/ResourceLocation;IIIFFIIII)V", ordinal = 4)
+    )
+    private void drawHungerTexture4(GuiGraphics context, ResourceLocation texture, int x, int y, int z, float u, float v, int width, int height, int textureWidth, int textureHeight, @Local(name = "i") int i, @Local(argsOnly = true) TooltipOverlayHandler.FoodOverlay foodOverlay) {
+        ((AppleskinTooltipRenderer) foodOverlay).renderHungerTooltip(context, texture, x, y, z, u, v, width, height, textureWidth, textureHeight, i);
+    }
+
+    @Redirect(
+            method = "onRenderTooltip(Lnet/minecraft/client/gui/GuiGraphics;Lsqueek/appleskin/client/TooltipOverlayHandler$FoodOverlay;IIILnet/minecraft/client/gui/Font;)V",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/GuiGraphics;blit(Lnet/minecraft/resources/ResourceLocation;IIIFFIIII)V", ordinal = 5)
+    )
+    private void drawHungerTexture5(GuiGraphics context, ResourceLocation texture, int x, int y, int z, float u, float v, int width, int height, int textureWidth, int textureHeight, @Local(name = "i") int i, @Local(argsOnly = true) TooltipOverlayHandler.FoodOverlay foodOverlay) {
+        ((AppleskinTooltipRenderer) foodOverlay).renderHungerTooltip(context, texture, x, y, z, u, v, width, height, textureWidth, textureHeight, i);
+    }
+
+    @Redirect(
+            method = "onRenderTooltip(Lnet/minecraft/client/gui/GuiGraphics;Lsqueek/appleskin/client/TooltipOverlayHandler$FoodOverlay;IIILnet/minecraft/client/gui/Font;)V",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/GuiGraphics;blit(Lnet/minecraft/resources/ResourceLocation;IIIFFIIII)V", ordinal = 6)
+    )
+    private void drawHungerTexture6(GuiGraphics context, ResourceLocation texture, int x, int y, int z, float u, float v, int width, int height, int textureWidth, int textureHeight, @Local(name = "i") int i, @Local(argsOnly = true) TooltipOverlayHandler.FoodOverlay foodOverlay) {
+        ((AppleskinTooltipRenderer) foodOverlay).renderHungerTooltip(context, texture, x, y, z, u, v, width, height, textureWidth, textureHeight, i);
+    }
+}

--- a/src/main/resources/mindful_eating.mixins.json
+++ b/src/main/resources/mindful_eating.mixins.json
@@ -14,6 +14,7 @@
   "client": [
     "GuiMixin",
     "appleskin.FoodOverlayMixin",
-    "appleskin.TooltipOverlayHandlerMixin"
+    "appleskin.TooltipOverlayHandlerMixin",
+    "appleskin.HUDOverlayHandlerMixin"
   ]
 }

--- a/src/main/resources/mindful_eating.mixins.json
+++ b/src/main/resources/mindful_eating.mixins.json
@@ -12,6 +12,8 @@
     "farmersdelight.PieBlockMixin"
   ],
   "client": [
-    "GuiMixin"
+    "GuiMixin",
+    "appleskin.FoodOverlayMixin",
+    "appleskin.TooltipOverlayHandlerMixin"
   ]
 }


### PR DESCRIPTION
- Modified AppleSkin tooltips to show appropriate food icons
- Reimplemented AppleSkin hunger and saturation previews with Mindful Eating food icons
- Modified hunger preview to display the new food type
- Added indicators for nourishment and/or hunger to the preview

I've done some basic testing that things work as expected with and without AppleSkin and/or Farmer's Delight loaded, and that the AppleSkin settings still seem to work as expected.