### PR TITLE
Restored old behaviour of Nutrition overlay

### DIFF
--- a/src/main/java/com/minecraftabnormals/mindful_eating/client/HungerOverlay.java
+++ b/src/main/java/com/minecraftabnormals/mindful_eating/client/HungerOverlay.java
@@ -1,6 +1,7 @@
 package com.minecraftabnormals.mindful_eating.client;
 
 import com.illusivesoulworks.diet.api.type.IDietGroup;
+import com.minecraftabnormals.mindful_eating.compat.FarmersDelightCompat;
 import com.minecraftabnormals.mindful_eating.core.MEConfig;
 import com.minecraftabnormals.mindful_eating.core.MindfulEatingFabric;
 import com.minecraftabnormals.mindful_eating.core.ext.MindfulEatingPlayer;
@@ -100,7 +101,7 @@ public class HungerOverlay {
 
             if (FabricLoader.getInstance().isModLoaded("farmersdelight")
                     && player.hasEffect(ModEffects.NOURISHMENT.get())
-                    && MEConfig.COMMON.nourishmentOverlay.get()) {
+                    && FarmersDelightCompat.NOURISHED_HUNGER_OVERLAY) {
                 texture = GUI_NOURISHMENT_ICONS_LOCATION;
                 icon -= player.hasEffect(MobEffects.HUNGER) ? 45 : 27;
                 background = 0;

--- a/src/main/java/com/minecraftabnormals/mindful_eating/compat/FarmersDelightCompat.java
+++ b/src/main/java/com/minecraftabnormals/mindful_eating/compat/FarmersDelightCompat.java
@@ -17,6 +17,7 @@ import java.util.Set;
 
 public class FarmersDelightCompat {
 
+    public static boolean NOURISHED_HUNGER_OVERLAY = Configuration.NOURISHED_HUNGER_OVERLAY.get();
     public static boolean ENABLE_STACKABLE_SOUP_ITEMS = Configuration.ENABLE_STACKABLE_SOUP_ITEMS.get();
 
     public static void cakeEatenCheck(Block block, Player player, ItemStack heldItem) {

--- a/src/main/java/com/minecraftabnormals/mindful_eating/core/MEConfig.java
+++ b/src/main/java/com/minecraftabnormals/mindful_eating/core/MEConfig.java
@@ -20,7 +20,6 @@ public class MEConfig {
         public final ForgeConfigSpec.ConfigValue<Boolean> proportionalDiet;
         public final ForgeConfigSpec.ConfigValue<Boolean> nativeDietBuffs;
         public final ForgeConfigSpec.ConfigValue<Double> exhaustionReduction;
-        public final ForgeConfigSpec.ConfigValue<Boolean> nourishmentOverlay;
         public final ForgeConfigSpec.ConfigValue<String>[] foodGroupExhaustion;
 
         Common(ForgeConfigSpec.Builder builder) {
@@ -30,7 +29,6 @@ public class MEConfig {
             proportionalDiet = builder.comment("Whether the saturation bonus is dependent on Diet's mechanics. If false, it will instead be based on the last food eaten. Default: false").define("Proportional Diet", false);
             nativeDietBuffs = builder.comment("Whether the buffs added by the Diet mod are enabled. Default: false").define("Native Diet Buffs", false);
             exhaustionReduction = builder.comment("The amount exhaustion is reduced by (if the above config is false). Default: 0.75").define("Exhaustion Reduction", 0.75);
-            nourishmentOverlay = builder.comment("Should the hunger bar have a gilded overlay when the player has the Nourishment effect? Disable the equivalent option in Farmer's Delight. Default: true").define("Nourishment Hunger Overlay", true);
 
             builder.pop();
             builder.comment("For multiple food groups, separate groups with a /, for example: fruits/vegetables.").push("exhaustion-sources");

--- a/src/main/java/com/minecraftabnormals/mindful_eating/core/mixin/farmersdelight/NourishmentHungerOverlayMixin.java
+++ b/src/main/java/com/minecraftabnormals/mindful_eating/core/mixin/farmersdelight/NourishmentHungerOverlayMixin.java
@@ -1,0 +1,18 @@
+package com.minecraftabnormals.mindful_eating.core.mixin.farmersdelight;
+
+import net.minecraft.client.gui.Gui;
+import net.minecraft.client.gui.GuiGraphics;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Pseudo
+@Mixin(vectorwing.farmersdelight.client.gui.NourishmentHungerOverlay.class)
+public class NourishmentHungerOverlayMixin {
+    @Inject(method = "renderNourishmentOverlay(Lnet/minecraft/client/gui/Gui;Lnet/minecraft/client/gui/GuiGraphics;)V", at = @At("HEAD"), cancellable = true)
+    private static void renderNourishmentOverlay(Gui gui, GuiGraphics guiGraphics, CallbackInfo callbackInfo) {
+        callbackInfo.cancel();
+    }
+}

--- a/src/main/resources/mindful_eating.mixins.json
+++ b/src/main/resources/mindful_eating.mixins.json
@@ -12,6 +12,7 @@
     "farmersdelight.PieBlockMixin"
   ],
   "client": [
-    "GuiMixin"
+    "GuiMixin",
+    "farmersdelight.NourishmentHungerOverlayMixin"
   ]
 }


### PR DESCRIPTION
Automatically disables Farmer's Delight rendering of overlay and replaces local setting with Farmer's delight setting again